### PR TITLE
change internal server error to less detailed message

### DIFF
--- a/pkg/http/rest/gesamtspielplan.go
+++ b/pkg/http/rest/gesamtspielplan.go
@@ -48,12 +48,11 @@ func addRouterGesamtspielplan(engine *gin.Engine) {
 		// get data from scrapper
 		html_scrape, err := scrape.ScrapeGesamtspielplan(season, championship, group)
 		if err != nil {
-			log.WithFields(
-				log.Fields{
-					"season":       season,
-					"championship": championship,
-					"group":        group,
-				},
+			log.WithFields(log.Fields{
+				"season":       season,
+				"championship": championship,
+				"group":        group,
+			},
 			).Warning(err)
 			c.String(http.StatusBadRequest, err.Error())
 			return

--- a/pkg/parser/gesamtspielplan.go
+++ b/pkg/parser/gesamtspielplan.go
@@ -64,11 +64,10 @@ func ParseGesamtspielplan(html colly.HTMLElement) (sport.Matches, error) {
 			case 3:
 				location, err := strconv.Atoi(t)
 				if err != nil {
-					log.WithFields(
-						log.Fields{
-							"locationId": t,
-							"error":      err,
-						}).Warning("can not parse location ID")
+					log.WithFields(log.Fields{
+						"locationId": t,
+						"error":      err,
+					}).Warning("can not parse location ID")
 				} else {
 					m.LocationId = location
 				}
@@ -77,11 +76,10 @@ func ParseGesamtspielplan(html colly.HTMLElement) (sport.Matches, error) {
 			case 4:
 				game, err := strconv.Atoi(t)
 				if err != nil {
-					log.WithFields(
-						log.Fields{
-							"gameId": t,
-							"error":  err,
-						}).Warning("can not parse game ID")
+					log.WithFields(log.Fields{
+						"gameId": t,
+						"error":  err,
+					}).Warning("can not parse game ID")
 				} else {
 					m.LocationId = game
 				}
@@ -98,14 +96,13 @@ func ParseGesamtspielplan(html colly.HTMLElement) (sport.Matches, error) {
 			case 7:
 				goalsHome, goalsGuest, annotation, referee, err := parseResult(t, td)
 				if err != nil {
-					log.WithFields(
-						log.Fields{
-							"goalsHome":  goalsHome,
-							"goalsGuest": goalsGuest,
-							"annotation": annotation,
-							"referee":    referee,
-							"err":        err,
-						}).Warning("can not parse result")
+					log.WithFields(log.Fields{
+						"goalsHome":  goalsHome,
+						"goalsGuest": goalsGuest,
+						"annotation": annotation,
+						"referee":    referee,
+						"err":        err,
+					}).Warning("can not parse result")
 				} else {
 					m.Goal.Home = goalsHome
 					m.Goal.Guest = goalsGuest

--- a/pkg/scrape/gesamtspielplan.go
+++ b/pkg/scrape/gesamtspielplan.go
@@ -9,12 +9,11 @@ import (
 
 // GenerateGesamtspielplan will scrape and generate Matches for a given group
 func ScrapeGesamtspielplan(s season.Season, c string, g group.Group) (colly.HTMLElement, error) {
-	log.WithFields(
-		log.Fields{
-			"season":       s,
-			"championship": c,
-			"group":        g,
-		},
+	log.WithFields(log.Fields{
+		"season":       s,
+		"championship": c,
+		"group":        g,
+	},
 	).Debug("generating new gesamtspielplan")
 
 	url := generateUrlGesamtspielplan(s, c, g)


### PR DESCRIPTION
The message for 500 error was to open - only a short and general message should be provided to API users.
Detailed information will be logged.

Also changed the log message structure when using `logrus.WithFields()` for better readability.