### PR TITLE
fix match id which always returned zero

### DIFF
--- a/pkg/parser/gesamtspielplan.go
+++ b/pkg/parser/gesamtspielplan.go
@@ -81,7 +81,7 @@ func ParseGesamtspielplan(html colly.HTMLElement) (sport.Matches, error) {
 						"error":  err,
 					}).Warning("can not parse game ID")
 				} else {
-					m.LocationId = game
+					m.Id = game
 				}
 
 			// hometeam


### PR DESCRIPTION
fixes bug from #22 which describes that match id always returns a `0`instead of the correct id.