### PR TITLE
restructure response of gesamtspielplan JSON

### DIFF
--- a/pkg/http/rest/gesamtspielplan.go
+++ b/pkg/http/rest/gesamtspielplan.go
@@ -61,7 +61,7 @@ func addRouterGesamtspielplan(engine *gin.Engine) {
 		// parse website content to Matches
 		matches, err := parser.ParseGesamtspielplan(html_scrape)
 		if err != nil {
-			err_msg := "parsing of gesamtspielplan failed"
+			err_msg := "parsing of matches failed"
 			log.WithFields(log.Fields{
 				"html_scrape": html_scrape,
 				"matches":     matches,
@@ -71,14 +71,21 @@ func addRouterGesamtspielplan(engine *gin.Engine) {
 			return
 		}
 
+		gsp := sport.Gesamtspielplan{
+			Season:       season,
+			Championship: championship,
+			Group:        group,
+			Matches:      matches,
+		}
+
 		// return matches as JSON
 		c.Writer.Header().Set("Content-Type", "application/json")
-		wr, err := json.Marshal(matches)
+		wr, err := json.Marshal(gsp)
 		if err != nil {
-			err_msg := "could not parse matches to JSON"
+			err_msg := "could not parse Gesamtspielplan to JSON"
 			log.WithFields(log.Fields{
-				"matches": matches,
-				"error":   err,
+				"gesamtspielplan": gsp,
+				"error":           err,
 			}).Warning(err_msg)
 			c.String(http.StatusInternalServerError, err_msg)
 			return

--- a/pkg/parser/gesamtspielplan.go
+++ b/pkg/parser/gesamtspielplan.go
@@ -18,8 +18,8 @@ import (
 type Parse colly.HTMLElement
 
 // ParseGesamtspielplan will parse a HTML table from nuLiga to Matches
-func ParseGesamtspielplan(html colly.HTMLElement) (sport.Matches, error) {
-	var matches sport.Matches
+func ParseGesamtspielplan(html colly.HTMLElement) ([]sport.Match, error) {
+	var matches []sport.Match
 	cachedDate := ""
 	skippedTableHeader := false
 

--- a/pkg/sport/match.go
+++ b/pkg/sport/match.go
@@ -2,10 +2,18 @@ package sport
 
 import (
 	"time"
+
+	"github.com/taskmedia/nuScrape/pkg/sport/group"
+	"github.com/taskmedia/nuScrape/pkg/sport/season"
 )
 
 // Matches represents a slice of multiple Match structs.
-type Matches []Match
+type Gesamtspielplan struct {
+	Matches      []Match
+	Season       season.Season
+	Championship string
+	Group        group.Group
+}
 
 // Match represents a nuLiga match (game)
 type Match struct {

--- a/pkg/sport/match.go
+++ b/pkg/sport/match.go
@@ -9,10 +9,10 @@ import (
 
 // Matches represents a slice of multiple Match structs.
 type Gesamtspielplan struct {
-	Matches      []Match
-	Season       season.Season
-	Championship string
-	Group        group.Group
+	Matches      []Match       `json:"matches" binding:"required"`
+	Season       season.Season `json:"season" binding:"required"`
+	Championship string        `json:"championship" binding:"required"`
+	Group        group.Group   `json:"group" binding:"required"`
 }
 
 // Match represents a nuLiga match (game)
@@ -30,7 +30,7 @@ type Match struct {
 	LocationId int `json:"location"`
 
 	// Id represents the unique ID of the match
-	Id int `json:"id"`
+	Id int `json:"id" binding:"required"`
 
 	// Annotation represents the annotations deposited for a match
 	Annotation matchAnnotation `json:"annotation"`


### PR DESCRIPTION
restructure response of Gesamtspielplan.

Added wrapper over matches and added season, championship and group.

```json
{
  "Matches": [...],
  "Season": "2021_22",
  "Championship": "AV",
  "Group": 281103
}
```