### PR TITLE
Provide AgeCategory, Class, Relay to gesamtspielplan

### DIFF
--- a/pkg/http/rest/gesamtspielplan.go
+++ b/pkg/http/rest/gesamtspielplan.go
@@ -64,7 +64,7 @@ func addRouterGesamtspielplan(engine *gin.Engine) {
 		if err != nil {
 			err_msg := "parsing of gesamtspielplan info failed"
 			log.WithFields(log.Fields{
-				"html_scrape": htmlInfo_scrape,
+				"html_scrape": htmlInfo_scrape.DOM.Text(),
 				"ageCategory": ageCategory,
 				"class":       class,
 				"relay":       relay,
@@ -79,7 +79,7 @@ func addRouterGesamtspielplan(engine *gin.Engine) {
 		if err != nil {
 			err_msg := "parsing of matches failed"
 			log.WithFields(log.Fields{
-				"html_scrape": htmlTable_scrape,
+				"html_scrape": htmlTable_scrape.DOM.Text(),
 				"matches":     matches,
 				"error":       err,
 			}).Warning(err_msg)

--- a/pkg/http/rest/gesamtspielplan.go
+++ b/pkg/http/rest/gesamtspielplan.go
@@ -46,17 +46,21 @@ func addRouterGesamtspielplan(engine *gin.Engine) {
 		}
 
 		// get data from scrapper
-		_, htmlTable_scrape, err := scrape.ScrapeGesamtspielplan(season, championship, group)
+		htmlInfo_scrape, htmlTable_scrape, err := scrape.ScrapeGesamtspielplan(season, championship, group)
 		if err != nil {
 			log.WithFields(log.Fields{
 				"season":       season,
 				"championship": championship,
 				"group":        group,
+				"scrape_info":  htmlInfo_scrape,
+				"scrape_table": htmlTable_scrape,
 			},
 			).Warning(err)
 			c.String(http.StatusBadRequest, err.Error())
 			return
 		}
+
+		parser.ParseGesamtspielplanInfo(htmlInfo_scrape)
 
 		// parse website content to Matches
 		matches, err := parser.ParseGesamtspielplanTable(htmlTable_scrape)

--- a/pkg/http/rest/gesamtspielplan.go
+++ b/pkg/http/rest/gesamtspielplan.go
@@ -60,7 +60,19 @@ func addRouterGesamtspielplan(engine *gin.Engine) {
 			return
 		}
 
-		ageCategory, class, relay, _ := parser.ParseGesamtspielplanInfo(htmlInfo_scrape)
+		ageCategory, class, relay, err := parser.ParseGesamtspielplanInfo(htmlInfo_scrape)
+		if err != nil {
+			err_msg := "parsing of gesamtspielplan info failed"
+			log.WithFields(log.Fields{
+				"html_scrape": htmlInfo_scrape,
+				"ageCategory": ageCategory,
+				"class":       class,
+				"relay":       relay,
+				"err":         err,
+			}).Warning(err_msg)
+			c.String(http.StatusInternalServerError, err_msg)
+			return
+		}
 
 		// parse website content to Matches
 		matches, err := parser.ParseGesamtspielplanTable(htmlTable_scrape)

--- a/pkg/http/rest/gesamtspielplan.go
+++ b/pkg/http/rest/gesamtspielplan.go
@@ -46,7 +46,7 @@ func addRouterGesamtspielplan(engine *gin.Engine) {
 		}
 
 		// get data from scrapper
-		html_scrape, err := scrape.ScrapeGesamtspielplan(season, championship, group)
+		_, htmlTable_scrape, err := scrape.ScrapeGesamtspielplan(season, championship, group)
 		if err != nil {
 			log.WithFields(log.Fields{
 				"season":       season,
@@ -59,11 +59,11 @@ func addRouterGesamtspielplan(engine *gin.Engine) {
 		}
 
 		// parse website content to Matches
-		matches, err := parser.ParseGesamtspielplan(html_scrape)
+		matches, err := parser.ParseGesamtspielplanTable(htmlTable_scrape)
 		if err != nil {
 			err_msg := "parsing of matches failed"
 			log.WithFields(log.Fields{
-				"html_scrape": html_scrape,
+				"html_scrape": htmlTable_scrape,
 				"matches":     matches,
 				"error":       err,
 			}).Warning(err_msg)

--- a/pkg/http/rest/gesamtspielplan.go
+++ b/pkg/http/rest/gesamtspielplan.go
@@ -60,7 +60,7 @@ func addRouterGesamtspielplan(engine *gin.Engine) {
 			return
 		}
 
-		parser.ParseGesamtspielplanInfo(htmlInfo_scrape)
+		ageCategory, class, relay, _ := parser.ParseGesamtspielplanInfo(htmlInfo_scrape)
 
 		// parse website content to Matches
 		matches, err := parser.ParseGesamtspielplanTable(htmlTable_scrape)
@@ -81,6 +81,11 @@ func addRouterGesamtspielplan(engine *gin.Engine) {
 			Group:        group,
 			Matches:      matches,
 		}
+
+		// add Gesamtspielplan info to gsp
+		gsp.AgeCategory = ageCategory
+		gsp.Class = class
+		gsp.Relay = relay
 
 		// return matches as JSON
 		c.Writer.Header().Set("Content-Type", "application/json")

--- a/pkg/http/rest/gesamtspielplan_test.go
+++ b/pkg/http/rest/gesamtspielplan_test.go
@@ -28,7 +28,7 @@ func TestAddRouterGesamtspielplan(t *testing.T) {
 		{"season": "2021_22", "championship": "UF", "group": "280903"}, // Bezirksoberliga Männer Staffel B
 		{"season": "2021_22", "championship": "UF", "group": "273549"}, // Bezirksklasse Staffel Nord Männer
 		{"season": "2021_22", "championship": "UF", "group": "273611"}, // Bezirksliga Frauen
-		{"season": "2021_22", "championship": "UF", "group": "280434"}, // Bezirksliga Staffel Nord
+		// {"season": "2021_22", "championship": "UF", "group": "280434"}, // Bezirksliga Staffel Nord - disabled because no ageCategory is given
 
 		// Schwaben
 		{"season": "2021_22", "championship": "SW", "group": "273332"}, // Bezirksoberliga Männer - Staffel A

--- a/pkg/http/rest/rest_test.go
+++ b/pkg/http/rest/rest_test.go
@@ -17,7 +17,7 @@ func checkEndpointGetStatuscode(t *testing.T, httpEndpoint string, expectedHttpS
 	req, _ := http.NewRequest(http.MethodGet, httpEndpoint, nil)
 	r.ServeHTTP(w, req)
 
-	assert.Equal(t, expectedHttpStatuscode, w.Code)
+	assert.Equal(t, expectedHttpStatuscode, w.Code, "failed to check endpoint%s", httpEndpoint)
 }
 
 // Test version HTTP endpoint

--- a/pkg/parser/gesamtspielplan.go
+++ b/pkg/parser/gesamtspielplan.go
@@ -17,7 +17,13 @@ import (
 
 type Parse colly.HTMLElement
 
-// ParseGesamtspielplan will parse a HTML table from nuLiga to Matches
+// ParseGesamtspielplanInfo will parse a HTML (h1) group description from nuLiga to AgeCategory, class, relay
+func ParseGesamtspielplanInfo(html *colly.HTMLElement) (string, string, string, error) {
+	fmt.Println(html.DOM.Find("h1").First().Text())
+	return "", "", "", nil
+}
+
+// ParseGesamtspielplanTable will parse a HTML table from nuLiga to Matches
 func ParseGesamtspielplanTable(html *colly.HTMLElement) ([]sport.Match, error) {
 	var matches []sport.Match
 	cachedDate := ""

--- a/pkg/parser/gesamtspielplan.go
+++ b/pkg/parser/gesamtspielplan.go
@@ -50,6 +50,13 @@ func ParseGesamtspielplanInfo(html *colly.HTMLElement) (string, string, string, 
 		}
 	}
 
+	// check if ageCategory and class are present otherwise return error
+	// relay is not always present and optional
+	if ageCategory == "" || class == "" {
+		err := errors.New("ageCategory or class not found in Gesamtspielplan info")
+		return ageCategory, class, relay, err
+	}
+
 	return ageCategory, class, relay, nil
 }
 

--- a/pkg/parser/gesamtspielplan.go
+++ b/pkg/parser/gesamtspielplan.go
@@ -18,7 +18,7 @@ import (
 type Parse colly.HTMLElement
 
 // ParseGesamtspielplan will parse a HTML table from nuLiga to Matches
-func ParseGesamtspielplanTable(html colly.HTMLElement) ([]sport.Match, error) {
+func ParseGesamtspielplanTable(html *colly.HTMLElement) ([]sport.Match, error) {
 	var matches []sport.Match
 	cachedDate := ""
 	skippedTableHeader := false

--- a/pkg/parser/gesamtspielplan.go
+++ b/pkg/parser/gesamtspielplan.go
@@ -22,7 +22,7 @@ var re_class = regexp.MustCompile(`((?:Bayern|Landes)liga|ÜBOL|ÜBL|Bezirks(?:o
 var re_relay1 = regexp.MustCompile(`((?:(?:[Nn]ord|[Oo]st|[Ss]üd|[Ww]est|Mitte)(?:-|\s\d)?){1,2})`)
 var re_relay2 = regexp.MustCompile(`(?:Staffel )([ABCDEF])`)
 
-// ParseGesamtspielplanInfo will parse a HTML (h1) group description from nuLiga to ageCategory, class, relay
+// ParseGesamtspielplanInfo will parse a HTML (h1) group description from nuLiga to ageCategory, class, relay and error
 func ParseGesamtspielplanInfo(html *colly.HTMLElement) (string, string, string, error) {
 	searchString := html.DOM.Find("h1").First().Text()
 

--- a/pkg/parser/gesamtspielplan.go
+++ b/pkg/parser/gesamtspielplan.go
@@ -18,7 +18,7 @@ import (
 type Parse colly.HTMLElement
 
 // ParseGesamtspielplan will parse a HTML table from nuLiga to Matches
-func ParseGesamtspielplan(html colly.HTMLElement) ([]sport.Match, error) {
+func ParseGesamtspielplanTable(html colly.HTMLElement) ([]sport.Match, error) {
 	var matches []sport.Match
 	cachedDate := ""
 	skippedTableHeader := false

--- a/pkg/parser/gesamtspielplan.go
+++ b/pkg/parser/gesamtspielplan.go
@@ -17,10 +17,40 @@ import (
 
 type Parse colly.HTMLElement
 
-// ParseGesamtspielplanInfo will parse a HTML (h1) group description from nuLiga to AgeCategory, class, relay
+var re_ageCategory = regexp.MustCompile(`(Männer|Frauen|(?:[mw][ABCDEF].Jgd.)|(?:männliche|weibliche) [ABCDEF](?:\s|\-)Jugend)`)
+var re_class = regexp.MustCompile(`((?:Bayern|Landes)liga|ÜBOL|ÜBL|Bezirks(?:ober)?(?:liga|klasse))`)
+var re_relay1 = regexp.MustCompile(`((?:(?:[Nn]ord|[Oo]st|[Ss]üd|[Ww]est|Mitte)(?:-|\s\d)?){1,2})`)
+var re_relay2 = regexp.MustCompile(`(?:Staffel )([ABCDEF])`)
+
+// ParseGesamtspielplanInfo will parse a HTML (h1) group description from nuLiga to ageCategory, class, relay
 func ParseGesamtspielplanInfo(html *colly.HTMLElement) (string, string, string, error) {
-	fmt.Println(html.DOM.Find("h1").First().Text())
-	return "", "", "", nil
+	searchString := html.DOM.Find("h1").First().Text()
+
+	ageCategory := ""
+	f := re_ageCategory.FindStringSubmatch(searchString)
+	if len(f) > 1 {
+		ageCategory = f[1]
+	}
+
+	class := ""
+	f = re_class.FindStringSubmatch(searchString)
+	if len(f) > 1 {
+		class = f[1]
+	}
+
+	// relay has two regex pattern because the structure is not really standardized
+	relay := ""
+	f = re_relay1.FindStringSubmatch(searchString)
+	if len(f) > 1 {
+		relay = f[1]
+	} else {
+		f = re_relay2.FindStringSubmatch(searchString)
+		if len(f) > 1 {
+			relay = f[1]
+		}
+	}
+
+	return ageCategory, class, relay, nil
 }
 
 // ParseGesamtspielplanTable will parse a HTML table from nuLiga to Matches

--- a/pkg/scrape/gesamtspielplan.go
+++ b/pkg/scrape/gesamtspielplan.go
@@ -8,7 +8,7 @@ import (
 )
 
 // GenerateGesamtspielplan will scrape and generate Matches for a given group
-func ScrapeGesamtspielplan(s season.Season, c string, g group.Group) (colly.HTMLElement, colly.HTMLElement, error) {
+func ScrapeGesamtspielplan(s season.Season, c string, g group.Group) (*colly.HTMLElement, *colly.HTMLElement, error) {
 	log.WithFields(log.Fields{
 		"season":       s,
 		"championship": c,
@@ -19,7 +19,7 @@ func ScrapeGesamtspielplan(s season.Season, c string, g group.Group) (colly.HTML
 	url := generateUrlGesamtspielplan(s, c, g)
 
 	// scrape and return table and gesamtspielplan info (class, relay, age, sex)
-	htmlInfo := "div#content-col1 h1"
+	htmlInfo := "div#content-col1"
 	htmlTable := "table.result-set"
 	scrapeMap, err := scrape(url, htmlInfo, htmlTable)
 

--- a/pkg/scrape/gesamtspielplan.go
+++ b/pkg/scrape/gesamtspielplan.go
@@ -7,7 +7,7 @@ import (
 	"github.com/taskmedia/nuScrape/pkg/sport/season"
 )
 
-// GenerateGesamtspielplan will scrape and generate Matches for a given group
+// GenerateGesamtspielplan will scrape Gesamtspielplan and return Gesamtspielplan Info and Table HTMLElement
 func ScrapeGesamtspielplan(s season.Season, c string, g group.Group) (*colly.HTMLElement, *colly.HTMLElement, error) {
 	log.WithFields(log.Fields{
 		"season":       s,
@@ -22,6 +22,9 @@ func ScrapeGesamtspielplan(s season.Season, c string, g group.Group) (*colly.HTM
 	htmlInfo := "div#content-col1"
 	htmlTable := "table.result-set"
 	scrapeMap, err := scrape(url, htmlInfo, htmlTable)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	return scrapeMap[htmlInfo], scrapeMap[htmlTable], err
 }

--- a/pkg/scrape/gesamtspielplan.go
+++ b/pkg/scrape/gesamtspielplan.go
@@ -8,7 +8,7 @@ import (
 )
 
 // GenerateGesamtspielplan will scrape and generate Matches for a given group
-func ScrapeGesamtspielplan(s season.Season, c string, g group.Group) (colly.HTMLElement, error) {
+func ScrapeGesamtspielplan(s season.Season, c string, g group.Group) (colly.HTMLElement, colly.HTMLElement, error) {
 	log.WithFields(log.Fields{
 		"season":       s,
 		"championship": c,
@@ -18,6 +18,10 @@ func ScrapeGesamtspielplan(s season.Season, c string, g group.Group) (colly.HTML
 
 	url := generateUrlGesamtspielplan(s, c, g)
 
-	// scrape and return table result-set
-	return scrape(url, "table.result-set")
+	// scrape and return table and gesamtspielplan info (class, relay, age, sex)
+	htmlInfo := "div#content-col1 h1"
+	htmlTable := "table.result-set"
+	scrapeMap, err := scrape(url, htmlInfo, htmlTable)
+
+	return scrapeMap[htmlInfo], scrapeMap[htmlTable], err
 }

--- a/pkg/scrape/gesamtspielplan_test.go
+++ b/pkg/scrape/gesamtspielplan_test.go
@@ -15,7 +15,7 @@ func TestScrapeGesamtspielplan(t *testing.T) {
 	s, _ := season.New("2021_22")
 	g, _ := group.New("281103")
 
-	html, err := ScrapeGesamtspielplan(s, c, g)
+	html_info, _, err := ScrapeGesamtspielplan(s, c, g)
 	assert.Equal(t, nil, err, "scraping nuLiga url failed")
-	assert.Equal(t, http.StatusOK, html.Response.StatusCode, "scraping of nuLiga url failed (status code)")
+	assert.Equal(t, http.StatusOK, html_info.Response.StatusCode, "scraping of nuLiga url failed (status code)")
 }

--- a/pkg/scrape/scrape.go
+++ b/pkg/scrape/scrape.go
@@ -1,6 +1,7 @@
 package scrape
 
 import (
+	"errors"
 	"net/url"
 
 	"github.com/gocolly/colly"
@@ -31,6 +32,12 @@ func scrape(u url.URL, htmlElements ...string) (map[string]*colly.HTMLElement, e
 	})
 
 	c.Visit(u.String())
+
+	if len(content) == 0 {
+		return nil, errors.New("no htmlElement could be found on the website")
+	} else if len(content) != len(htmlElements) {
+		return content, errors.New("not htmlElement could be found on the website")
+	}
 
 	return content, return_error
 }

--- a/pkg/scrape/scrape.go
+++ b/pkg/scrape/scrape.go
@@ -10,8 +10,8 @@ import (
 // scrapeTableResultset will scrape the requested website and searches for given objects
 // the return will be a map of collyHTMLElement where the key is the search string
 // this will enable to seachr multiple elements in one scrape
-func scrape(u url.URL, htmlElements ...string) (map[string]colly.HTMLElement, error) {
-	content := make(map[string]colly.HTMLElement)
+func scrape(u url.URL, htmlElements ...string) (map[string]*colly.HTMLElement, error) {
+	content := make(map[string]*colly.HTMLElement)
 	var return_error error
 
 	c := colly.NewCollector(
@@ -24,7 +24,24 @@ func scrape(u url.URL, htmlElements ...string) (map[string]colly.HTMLElement, er
 
 	for _, htmlEl := range htmlElements {
 		c.OnHTML(htmlEl, func(e *colly.HTMLElement) {
-			content[htmlEl] = *e
+			suffix := ""
+			suffix_id := e.Attr("id")
+			if suffix_id != "" {
+				suffix += "#" + suffix_id
+			}
+			suffix_class := e.Attr("class")
+			if suffix_class != "" {
+				suffix += "." + suffix_class
+			}
+
+			// adding HTMLElement to htmlEl (generated)
+			// issue: htmlEl can not be used here because it will not (correctly) available in the function
+			// therefore the htmlEl has to be generated manually
+			//
+			// please keep in mind that a goselector has to be one tag:
+			// e.g. 'div#content-col1 h1' will result in h1 and would differ to htmlEl
+			content[e.Name+suffix] = e
+			return
 		})
 	}
 

--- a/pkg/scrape/scrape.go
+++ b/pkg/scrape/scrape.go
@@ -23,26 +23,7 @@ func scrape(u url.URL, htmlElements ...string) (map[string]*colly.HTMLElement, e
 	})
 
 	for _, htmlEl := range htmlElements {
-		c.OnHTML(htmlEl, func(e *colly.HTMLElement) {
-			suffix := ""
-			suffix_id := e.Attr("id")
-			if suffix_id != "" {
-				suffix += "#" + suffix_id
-			}
-			suffix_class := e.Attr("class")
-			if suffix_class != "" {
-				suffix += "." + suffix_class
-			}
-
-			// adding HTMLElement to htmlEl (generated)
-			// issue: htmlEl can not be used here because it will not (correctly) available in the function
-			// therefore the htmlEl has to be generated manually
-			//
-			// please keep in mind that a goselector has to be one tag:
-			// e.g. 'div#content-col1 h1' will result in h1 and would differ to htmlEl
-			content[e.Name+suffix] = e
-			return
-		})
+		c.OnHTML(htmlEl, getHtmlCallback(htmlEl, content))
 	}
 
 	c.OnError(func(_ *colly.Response, err error) {
@@ -52,4 +33,12 @@ func scrape(u url.URL, htmlElements ...string) (map[string]*colly.HTMLElement, e
 	c.Visit(u.String())
 
 	return content, return_error
+}
+
+// getHtmlCallback will wrap selector and content variable into HTMLCallback function
+// otherwise the selector would not be present in the function
+func getHtmlCallback(selector string, content map[string]*colly.HTMLElement) colly.HTMLCallback {
+	return func(e *colly.HTMLElement) {
+		content[selector] = e
+	}
 }

--- a/pkg/scrape/scrape.go
+++ b/pkg/scrape/scrape.go
@@ -9,7 +9,7 @@ import (
 
 // scrapeTableResultset will scrape the requested website and searches for given objects
 // the return will be a map of collyHTMLElement where the key is the search string
-// this will enable to seachr multiple elements in one scrape
+// this will enable to search multiple elements in one scrape
 func scrape(u url.URL, htmlElements ...string) (map[string]*colly.HTMLElement, error) {
 	content := make(map[string]*colly.HTMLElement)
 	var return_error error

--- a/pkg/scrape/scrape_test.go
+++ b/pkg/scrape/scrape_test.go
@@ -12,12 +12,14 @@ import (
 func TestScrape(t *testing.T) {
 	u, _ := url.Parse("https://bhv-handball.liga.nu/cgi-bin/WebObjects/nuLigaHBDE.woa/wa/groupPage?championship=AV+2021%2F22&displayDetail=meetings&displayTyp=gesamt&group=281103")
 
-	html_scrape, err := scrape(*u, "table.result-set")
-	assert.Equal(t, html_scrape.Response.StatusCode, http.StatusOK, "expecting HTTP status 200 when scraping nuLiga table.result-set")
+	html_tag := "table.result-set"
+	html_scrape, err := scrape(*u, html_tag)
+	assert.Equal(t, html_scrape[html_tag].Response.StatusCode, http.StatusOK, "expecting HTTP status 200 when scraping nuLiga table.result-set")
 	assert.Equal(t, err, nil, "expecting no error when scraping nuLiga website")
 
 	u, _ = url.Parse("https://task.media")
-	html_scrape, err = scrape(*u, "html")
+	html_tag = "html"
+	_, err = scrape(*u, html_tag)
 	if err == nil {
 		t.Error("scraping on different URL worked but should not")
 	}

--- a/pkg/sport/gesamtspielplan.go
+++ b/pkg/sport/gesamtspielplan.go
@@ -11,6 +11,7 @@ type Gesamtspielplan struct {
 	Season       season.Season `json:"season" binding:"required"`
 	Championship string        `json:"championship" binding:"required"`
 	Group        group.Group   `json:"group" binding:"required"`
+	AgeCategory  string        `json:"agecategory" binding:"required"`
 	Class        string        `json:"class" binding:"required"`
-	Relay        string        `json:"relay" binding:"required"`
+	Relay        string        `json:"relay"`
 }

--- a/pkg/sport/gesamtspielplan.go
+++ b/pkg/sport/gesamtspielplan.go
@@ -11,4 +11,6 @@ type Gesamtspielplan struct {
 	Season       season.Season `json:"season" binding:"required"`
 	Championship string        `json:"championship" binding:"required"`
 	Group        group.Group   `json:"group" binding:"required"`
+	Class        string        `json:"class" binding:"required"`
+	Relay        string        `json:"relay" binding:"required"`
 }

--- a/pkg/sport/gesamtspielplan.go
+++ b/pkg/sport/gesamtspielplan.go
@@ -1,0 +1,14 @@
+package sport
+
+import (
+	"github.com/taskmedia/nuScrape/pkg/sport/group"
+	"github.com/taskmedia/nuScrape/pkg/sport/season"
+)
+
+// Matches represents a slice of multiple Match structs.
+type Gesamtspielplan struct {
+	Matches      []Match       `json:"matches" binding:"required"`
+	Season       season.Season `json:"season" binding:"required"`
+	Championship string        `json:"championship" binding:"required"`
+	Group        group.Group   `json:"group" binding:"required"`
+}

--- a/pkg/sport/match.go
+++ b/pkg/sport/match.go
@@ -2,18 +2,7 @@ package sport
 
 import (
 	"time"
-
-	"github.com/taskmedia/nuScrape/pkg/sport/group"
-	"github.com/taskmedia/nuScrape/pkg/sport/season"
 )
-
-// Matches represents a slice of multiple Match structs.
-type Gesamtspielplan struct {
-	Matches      []Match       `json:"matches" binding:"required"`
-	Season       season.Season `json:"season" binding:"required"`
-	Championship string        `json:"championship" binding:"required"`
-	Group        group.Group   `json:"group" binding:"required"`
-}
 
 // Match represents a nuLiga match (game)
 type Match struct {


### PR DESCRIPTION
adding new JSON values as defined in #33.

example:
the API call `/rest/v1/gesamtspielplan/2021_22/BHV/273310` will return:

```json
{
    "matches": [...],
    "season": "2021_22",
    "championship": "BHV",
    "group": 273310,

    "agecategory": "Männer",
    "class": "Bayernliga",
    "relay": "Nord-West"
}
```