### PR TITLE
add class and relay abbreviations

### DIFF
--- a/pkg/sport/class/class.go
+++ b/pkg/sport/class/class.go
@@ -1,0 +1,55 @@
+package class
+
+import log "github.com/sirupsen/logrus"
+
+var classMap = map[string]string{
+	"Bayernliga":      "BL",
+	"Landesliga":      "LL",
+	"Bezirksoberliga": "BOL",
+	"Bezirksliga":     "BZL",
+	"Bezirksklasse":   "BZK",
+
+	// the following classes are mostly not referenced with fullname
+	"BZL":  "BZL",  // Bezirksliga
+	"BZK":  "BZK",  // Bezirksklasse
+	"ÜBOL": "ÜBOL", // Übergreifende Bezirksoberliga
+	"ÜBL":  "ÜBL",  // Übergreifende Bezirksliga
+	"ÜBK":  "ÜBK",  // Übergreifende Bezirksklasse
+
+	// never used - but due list completion added
+	"Übergreifende Bezirksoberliga": "ÜBOL",
+	"Übergreifende Bezirksliga":     "ÜBL",
+	"Übergreifende Bezirksklasse":   "ÜBK",
+}
+
+// GetAbbreviation returns the abbreviation of a class
+// input will be the complete name of the class
+func GetAbbreviation(name string) string {
+	if len(name) <= 4 {
+		return name
+	}
+
+	for n, a := range classMap {
+		if name == n {
+			return a
+		}
+	}
+
+	log.Warning("could not find abbreviation for class %s", name)
+
+	return name
+}
+
+// GetFullname returns the complete name of a class
+// input will be the abbreviation of that class
+func GetFullname(abbreviation string) string {
+	for n, a := range classMap {
+		if a == abbreviation {
+			return n
+		}
+	}
+
+	log.Warning("could not find fullname for class %s", abbreviation)
+
+	return abbreviation
+}

--- a/pkg/sport/class/class.go
+++ b/pkg/sport/class/class.go
@@ -24,20 +24,20 @@ var classMap = map[string]string{
 
 // GetAbbreviation returns the abbreviation of a class
 // input will be the complete name of the class
-func GetAbbreviation(name string) string {
-	if len(name) <= 4 {
-		return name
+func GetAbbreviation(fullname string) string {
+	if len(fullname) <= 4 {
+		return fullname
 	}
 
 	for n, a := range classMap {
-		if name == n {
+		if fullname == n {
 			return a
 		}
 	}
 
-	log.Warning("could not find abbreviation for class %s", name)
+	log.WithField("fullname", fullname).Warning("could not find abbreviation for class")
 
-	return name
+	return fullname
 }
 
 // GetFullname returns the complete name of a class
@@ -49,7 +49,7 @@ func GetFullname(abbreviation string) string {
 		}
 	}
 
-	log.Warning("could not find fullname for class %s", abbreviation)
+	log.WithField("abbreviation", abbreviation).Warning("could not find fullname for class")
 
 	return abbreviation
 }

--- a/pkg/sport/class/class.go
+++ b/pkg/sport/class/class.go
@@ -1,6 +1,10 @@
 package class
 
-import log "github.com/sirupsen/logrus"
+import (
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
 
 var classMap = map[string]string{
 	"Bayernliga":      "BL",
@@ -30,7 +34,7 @@ func GetAbbreviation(fullname string) string {
 	}
 
 	for n, a := range classMap {
-		if fullname == n {
+		if strings.ToLower(fullname) == strings.ToLower(n) {
 			return a
 		}
 	}
@@ -44,7 +48,7 @@ func GetAbbreviation(fullname string) string {
 // input will be the abbreviation of that class
 func GetFullname(abbreviation string) string {
 	for n, a := range classMap {
-		if a == abbreviation {
+		if strings.ToLower(a) == strings.ToLower(abbreviation) {
 			return n
 		}
 	}

--- a/pkg/sport/class/class_test.go
+++ b/pkg/sport/class/class_test.go
@@ -8,13 +8,13 @@ import (
 
 // Test func TestGetAbbreviation if it returns the correct abbreviation
 func TestGetAbbreviation(t *testing.T) {
-	assert.Equal(t, "BL", GetAbbreviation("Bayernliga"), "Expected abbreviation was not correct for Bayernliga")
-	assert.Equal(t, "BOL", GetAbbreviation("Bezirksoberliga"), "Expected abbreviation was not correct for Bezirksoberliga")
-	assert.Equal(t, "ÜBOL", GetAbbreviation("ÜBOL"), "Expected abbreviation was not correct for ÜBOL")
+	assert.Equal(t, "BL", GetAbbreviation("Bayernliga"), "Expected class abbreviation was not correct for Bayernliga")
+	assert.Equal(t, "BOL", GetAbbreviation("Bezirksoberliga"), "Expected class abbreviation was not correct for Bezirksoberliga")
+	assert.Equal(t, "ÜBOL", GetAbbreviation("ÜBOL"), "Expected class abbreviation was not correct for ÜBOL")
 }
 
 // Test func TestGetFullname if it returns the correct complete name of a class
 func TestGetFullname(t *testing.T) {
-	assert.Equal(t, "Landesliga", GetFullname("LL"), "Expected fullname was not correct for LL")
+	assert.Equal(t, "Landesliga", GetFullname("LL"), "Expected class fullname was not correct for LL")
 	// assert.Equal(t, "Bezirksklasse", GetFullname("BZK"), "Expected fullname was not correct for BZK") // not possible because duplicate entries
 }

--- a/pkg/sport/class/class_test.go
+++ b/pkg/sport/class/class_test.go
@@ -1,0 +1,20 @@
+package class
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test func TestGetAbbreviation if it returns the correct abbreviation
+func TestGetAbbreviation(t *testing.T) {
+	assert.Equal(t, "BL", GetAbbreviation("Bayernliga"), "Expected abbreviation was not correct for Bayernliga")
+	assert.Equal(t, "BOL", GetAbbreviation("Bezirksoberliga"), "Expected abbreviation was not correct for Bezirksoberliga")
+	assert.Equal(t, "ÜBOL", GetAbbreviation("ÜBOL"), "Expected abbreviation was not correct for ÜBOL")
+}
+
+// Test func TestGetFullname if it returns the correct complete name of a class
+func TestGetFullname(t *testing.T) {
+	assert.Equal(t, "Landesliga", GetFullname("LL"), "Expected fullname was not correct for LL")
+	// assert.Equal(t, "Bezirksklasse", GetFullname("BZK"), "Expected fullname was not correct for BZK") // not possible because duplicate entries
+}

--- a/pkg/sport/relay/relay.go
+++ b/pkg/sport/relay/relay.go
@@ -1,0 +1,59 @@
+package relay
+
+import (
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var relayMap = map[string]string{
+	"Nord":      "N",
+	"Nord-Ost":  "NO",
+	"Nord-West": "NW",
+
+	"Ost": "O",
+
+	"Süd":      "S",
+	"Süd-Ost":  "SO",
+	"Süd-West": "SW",
+
+	"West": "W",
+
+	"Mitte": "M",
+
+	"A": "A",
+	"B": "B",
+	"C": "C",
+	"D": "D",
+	"E": "E",
+	"F": "F",
+}
+
+// GetAbbreviation returns the abbreviation of a relay
+// input will be the complete name of the relay
+func GetAbbreviation(fullname string) string {
+	for n, a := range relayMap {
+		// dash will be removed because sometimes it is not provided
+		if strings.ReplaceAll(strings.ToLower(fullname), "-", "") == strings.ReplaceAll(strings.ToLower(n), "-", "") {
+			return a
+		}
+	}
+
+	log.WithField("fullname", fullname).Warning("could not find abbreviation for relay")
+
+	return fullname
+}
+
+// GetFullname returns the complete name of a relay
+// input will be the abbreviation of that relay
+func GetFullname(abbreviation string) string {
+	for n, a := range relayMap {
+		if strings.ToLower(a) == strings.ToLower(abbreviation) {
+			return n
+		}
+	}
+
+	log.WithField("abbreviation", abbreviation).Warning("could not find fullname for relay")
+
+	return abbreviation
+}

--- a/pkg/sport/relay/relay_test.go
+++ b/pkg/sport/relay/relay_test.go
@@ -1,0 +1,24 @@
+package relay
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test func TestGetAbbreviation if it returns the correct abbreviation
+func TestGetAbbreviation(t *testing.T) {
+	assert.Equal(t, "N", GetAbbreviation("Nord"), "Expected relay abbreviation was not correct for Nord")
+	assert.Equal(t, "NW", GetAbbreviation("Nord-West"), "Expected relay abbreviation was not correct for Nord-West")
+	assert.Equal(t, "SO", GetAbbreviation("Südost"), "Expected relay abbreviation was not correct for Südost")
+	assert.Equal(t, "B", GetAbbreviation("B"), "Expected relay abbreviation was not correct for B")
+}
+
+// Test func TestGetFullname if it returns the correct complete name of a class
+func TestGetFullname(t *testing.T) {
+	assert.Equal(t, "Nord-West", GetFullname("NW"), "Expected relay fullname was not correct for NW")
+	assert.Equal(t, "Süd-Ost", GetFullname("SO"), "Expected relay fullname was not correct for SO")
+	assert.Equal(t, "Mitte", GetFullname("M"), "Expected relay fullname was not correct for M")
+	assert.Equal(t, "A", GetFullname("A"), "Expected relay fullname was not correct for A")
+
+}


### PR DESCRIPTION
this helps to get abbreviations to class and relay strings

it should be used in ICS title instead of fullname