### PR TITLE
adding abbriviation and name functions to relay

### DIFF
--- a/pkg/sport/relay/relay.go
+++ b/pkg/sport/relay/relay.go
@@ -1,6 +1,7 @@
 package relay
 
 import (
+	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -18,6 +19,36 @@ var replacer = strings.NewReplacer("-", "", " ", "")
 
 // searches for a number in unified relay
 var re_relayNumber = regexp.MustCompile(`(.*)(\d)$`)
+
+// func GetAbbreviation returns short name of a relay
+// if no relay given a empty string will be returned
+func (r Relay) GetAbbreviation() string {
+	if r.Name == "" {
+		return ""
+	}
+
+	// check if no ID is provided
+	if r.Id == 0 || r.Id == -1 {
+		return r.Name.GetAbbreviation()
+	}
+
+	return fmt.Sprintf("%s %d", r.Name.GetAbbreviation(), r.Id)
+}
+
+// func GetName returns the full name of a relay
+// if no relay given a empty string will be returned
+func (r Relay) GetName() string {
+	if r.Name == "" {
+		return ""
+	}
+
+	// check if no ID is provided
+	if r.Id == 0 || r.Id == -1 {
+		return r.Name.GetName()
+	}
+
+	return fmt.Sprintf("%s %d", r.Name.GetName(), r.Id)
+}
 
 // func Parse converts a given string to a Relay
 // it tries to convert different styles of relays to a Relay type

--- a/pkg/sport/relay/relay_test.go
+++ b/pkg/sport/relay/relay_test.go
@@ -7,6 +7,38 @@ import (
 	"github.com/taskmedia/nuScrape/pkg/sport/relay/relayName"
 )
 
+// Test func GetAbbreviation if it returns the correct abbreviation of a relay
+func TestGetAbbreviation(t *testing.T) {
+	testRelay := map[string]Relay{
+		"N":   Relay{Name: relayName.N, Id: -1},
+		"SW":  Relay{Name: relayName.SW, Id: -1},
+		"W 2": Relay{Name: relayName.W, Id: 2},
+		"M":   Relay{Name: relayName.M, Id: -1},
+		"B":   Relay{Name: relayName.B, Id: -1},
+		"":    Relay{},
+	}
+
+	for check, expected := range testRelay {
+		assert.Equal(t, check, expected.GetAbbreviation(), "expected other abbreviation from relay %s", check)
+	}
+}
+
+// Test func GetName if it returns the correct full name of a relay
+func TestGetName(t *testing.T) {
+	testRelay := map[string]Relay{
+		"Nord":     Relay{Name: relayName.N, Id: -1},
+		"Süd-West": Relay{Name: relayName.SW, Id: -1},
+		"West 2":   Relay{Name: relayName.W, Id: 2},
+		"Mitte":    Relay{Name: relayName.M, Id: -1},
+		"B":        Relay{Name: relayName.B, Id: -1},
+		"":         Relay{},
+	}
+
+	for check, expected := range testRelay {
+		assert.Equal(t, check, expected.GetName(), "expected other full name from relay %s", check)
+	}
+}
+
 // Test func Parse if it returns the correct relay
 func TestParse(t *testing.T) {
 	testRelays := map[string]Relay{


### PR DESCRIPTION
adding function `GetAbbreviation` and `GetName` for package `relay` with tests.

