### PR TITLE
add description func for GSP and match

### DIFF
--- a/pkg/sport/gesamtspielplan.go
+++ b/pkg/sport/gesamtspielplan.go
@@ -37,3 +37,14 @@ func (gsp Gesamtspielplan) GetDistinctTeams() []string {
 	}
 	return dt
 }
+
+// func GetDescription will return a formatted description (multi line) of the GSP (without matches)
+func (gsp Gesamtspielplan) GetDescription() string {
+	desc := ""
+	desc += "Liga: " + gsp.Championship + " - " + gsp.Class.GetName() + " " + gsp.Relay.GetName() + "\n"
+	desc += "Gruppennummer: " + gsp.Group.String() + "\n"
+	desc += "Altersklasse: " + gsp.AgeCategory.GetName() + "\n"
+	desc += "Saison: " + string(gsp.Season) + "\n"
+
+	return desc
+}

--- a/pkg/sport/match.go
+++ b/pkg/sport/match.go
@@ -1,6 +1,7 @@
 package sport
 
 import (
+	"strconv"
 	"time"
 
 	"github.com/taskmedia/nuScrape/pkg/sport/annotationResult"
@@ -60,4 +61,39 @@ type matchGoal struct {
 
 	// Guest represents the achieved goals of the guest team
 	Guest int `json:"guest"`
+}
+
+// func GetDescription will return a formatted description (multi line) of the match
+func (m Match) GetDescription() string {
+	// `Liga: %s
+	// Klasse: %s
+	// Altersklasse:
+
+	desc := ""
+	desc += "Heim: " + m.Team.Home + "\n"
+	desc += "Gast: " + m.Team.Guest + "\n"
+	if m.Goal.Home != 0 {
+		desc += "Ergebnis: " + strconv.Itoa(m.Goal.Home) + ":" + strconv.Itoa(m.Goal.Guest) + "\n"
+	}
+	desc += "Spielnummer: " + strconv.Itoa(m.Id) + "\n"
+	if m.LocationId != 0 {
+		desc += "Hallennummer: " + strconv.Itoa(m.LocationId) + "\n"
+	}
+	if m.Referee != nil {
+		desc += "Schiedsrichter:\n"
+		for _, ref := range m.Referee {
+			desc += "  - " + ref + "\n"
+		}
+	}
+	if m.Annotation.Date != "" || m.Annotation.Result != "" {
+		desc += "Anmerkungen:\n"
+		if m.Annotation.Date != "" {
+			desc += "  - " + m.Annotation.Date + "\n"
+		}
+		if m.Annotation.Result != "" {
+			desc += "  - " + m.Annotation.Result.GetName() + "\n"
+		}
+	}
+
+	return desc
 }


### PR DESCRIPTION
Add function to return string of all relevant elements of a Gesamtspielplan and Match.
This can be used in nuCal to create calandar entries. 